### PR TITLE
🏄 :: (Meogo-52) feign client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-s3:1.12.529")
     implementation("com.google.firebase:firebase-admin:8.1.0")
     implementation("javax.servlet:javax.servlet-api:4.0.1")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("com.mysql:mysql-connector-j")
     annotationProcessor("org.projectlombok:lombok")

--- a/src/main/kotlin/org/meogo/MeogoBackendApplication.kt
+++ b/src/main/kotlin/org/meogo/MeogoBackendApplication.kt
@@ -4,7 +4,9 @@ import org.meogo.global.jwt.JwtProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 
+@EnableFeignClients(basePackages = ["org.meogo"])
 @EnableConfigurationProperties(JwtProperties::class)
 @SpringBootApplication(scanBasePackages = [ "org.meogo"])
 class MeogoBackendApplication

--- a/src/main/kotlin/org/meogo/domain/bookmark/presentation/BookmarkController.kt
+++ b/src/main/kotlin/org/meogo/domain/bookmark/presentation/BookmarkController.kt
@@ -1,5 +1,7 @@
 package org.meogo.domain.bookmark.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.meogo.domain.bookmark.service.BookmarkService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -10,25 +12,30 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Bookmark API")
 @RestController
 @RequestMapping("/bookmark")
 class BookmarkController(
     private val bookmarkService: BookmarkService
 ) {
 
+    @Operation(summary = "북마크 생성")
     @ResponseStatus(HttpStatus.OK)
     @PostMapping
     fun create(@RequestParam(name = "school_id")schoolId: Int) =
         bookmarkService.execute(schoolId)
 
+    @Operation(summary = "내 북마크 조회")
     @GetMapping("/query/my")
     fun myBookmarks() =
         bookmarkService.queryBookmarkedSchool()
 
+    @Operation(summary = "북마크 여부 조회")
     @GetMapping("/query")
     fun isBookmarked(@RequestParam(name = "school_id")schoolId: Int) =
         bookmarkService.queryIsBookmarked(schoolId)
 
+    @Operation(summary = "북마크 취소")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping
     fun delete(@RequestParam(name = "school_id")schoolId: Int) =

--- a/src/main/kotlin/org/meogo/domain/comment/presentation/CommentController.kt
+++ b/src/main/kotlin/org/meogo/domain/comment/presentation/CommentController.kt
@@ -1,5 +1,7 @@
 package org.meogo.domain.comment.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.meogo.domain.comment.presentation.dto.request.CommentRequest
 import org.meogo.domain.comment.service.CreateCommentService
 import org.meogo.domain.comment.service.DeleteCommentService
@@ -13,12 +15,14 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
 
+@Tag(name = "Comment API")
 @RestController
 @RequestMapping("/comment")
 class CommentController(
     private val createCommentService: CreateCommentService,
     private val deleteCommentService: DeleteCommentService
 ) {
+    @Operation(summary = "댓글 작성")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun create(
@@ -26,6 +30,7 @@ class CommentController(
         request: CommentRequest
     ) = createCommentService.execute(request)
 
+    @Operation(summary = "댓글 삭제")
     @DeleteMapping()
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@RequestParam(name = "comment_id")id: Long) =

--- a/src/main/kotlin/org/meogo/domain/post/presentation/PostController.kt
+++ b/src/main/kotlin/org/meogo/domain/post/presentation/PostController.kt
@@ -47,13 +47,13 @@ class PostController(
     ) =
         createPostService.execute(request, image)
 
-    @Operation(summary = "댓글 삭제")
+    @Operation(summary = "게시글 삭제")
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@RequestParam("post_id") id: Long) =
         deletePostService.execute(id)
 
-    @Operation(summary = "댓글 수정")
+    @Operation(summary = "게시글 수정")
     @PatchMapping("/modify")
     fun modify(
         @RequestParam("post_id") id: Long,

--- a/src/main/kotlin/org/meogo/domain/post/presentation/PostController.kt
+++ b/src/main/kotlin/org/meogo/domain/post/presentation/PostController.kt
@@ -1,6 +1,7 @@
 package org.meogo.domain.post.presentation
 
-import lombok.RequiredArgsConstructor
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.meogo.domain.post.presentation.dto.request.PostRequest
 import org.meogo.domain.post.service.CreatePostService
 import org.meogo.domain.post.service.DeletePostService
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import javax.validation.Valid
 
-@RequiredArgsConstructor
+@Tag(name = "Community API")
 @RestController
 @RequestMapping("/community")
 class PostController(
@@ -35,6 +36,7 @@ class PostController(
     private val queryMyPostService: QueryMyPostService
 ) {
 
+    @Operation(summary = "게시글 작성")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun create(
@@ -45,11 +47,13 @@ class PostController(
     ) =
         createPostService.execute(request, image)
 
-    @DeleteMapping()
+    @Operation(summary = "댓글 삭제")
+    @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@RequestParam("post_id") id: Long) =
         deletePostService.execute(id)
 
+    @Operation(summary = "댓글 수정")
     @PatchMapping("/modify")
     fun modify(
         @RequestParam("post_id") id: Long,
@@ -59,16 +63,20 @@ class PostController(
         @RequestPart("image") image: MultipartFile?
     ) = modifyPostService.execute(id, request, image)
 
+    @Operation(summary = "모든 게시글 조회")
     @GetMapping("/query/all")
     fun queryAll() = queryAllPostService.execute()
 
+    @Operation(summary = "학교별 게시글 조회")
     @GetMapping("/query")
     fun querySchool(@RequestParam(name = "school_id") schoolId: Int) = querySchoolPostService.execute(schoolId)
 
+    @Operation(summary = "게시글 상세보기")
     @GetMapping("/query/detail")
     fun queryPostDetail(@RequestParam(name = "post_id") id: Long) =
         queryPostDetailService.execute(id)
 
+    @Operation(summary = "내가 쓴 게시글 조회")
     @GetMapping("/query/my")
     fun queryMyPosts() = queryMyPostService.execute()
 }

--- a/src/main/kotlin/org/meogo/domain/question/presentation/QuestionController.kt
+++ b/src/main/kotlin/org/meogo/domain/question/presentation/QuestionController.kt
@@ -1,5 +1,7 @@
 package org.meogo.domain.question.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.meogo.domain.question.enum.QuestionType
 import org.meogo.domain.question.presentation.dto.request.ModifyQuestionRequest
 import org.meogo.domain.question.presentation.dto.request.QuestionRequest
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
 
+@Tag(name = "Question API")
 @RestController
 @RequestMapping("/question")
 class QuestionController(
@@ -31,6 +34,7 @@ class QuestionController(
     private val modifyQuestionService: ModifyQuestionService,
     private val deleteQuestionService: DeleteQuestionService
 ) {
+    @Operation(summary = "질문 작성")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     fun createQuestion(
@@ -38,6 +42,7 @@ class QuestionController(
         request: QuestionRequest
     ) = createQuestionService.execute(request)
 
+    @Operation(summary = "질문 수정")
     @PatchMapping("/modify")
     fun modifyQuestion(
         @RequestParam(name = "question_id")
@@ -47,22 +52,26 @@ class QuestionController(
     ) =
         modifyQuestionService.execute(questionId, request)
 
+    @Operation(summary = "학교별 질문 조회")
     @GetMapping("/query")
     fun querySchoolQuestion(@RequestParam(name = "school_id")schoolId: Int) =
         querySchoolQuestionService.execute(schoolId)
 
+    @Operation(summary = "학교별 + 태그별 질문 조회")
     @GetMapping("/query/tag")
     fun queryTypeQuestion(
         @RequestParam(name = "school_id")schoolId: Int,
         @RequestParam(name = "tag") type: QuestionType
     ) = queryTypeQuestionService.execute(schoolId, type)
 
+    @Operation(summary = "질문 상세보기")
     @GetMapping("/detail")
     fun queryDetail(@RequestParam(name = "question_id")questionId: Long) =
         queryDetailQuestionService.execute(questionId)
 
+    @Operation(summary = "질문 삭제")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping()
+    @DeleteMapping
     fun deleteQuestion(@RequestParam(name = "question_id")questionId: Long) =
         deleteQuestionService.execute(questionId)
 }

--- a/src/main/kotlin/org/meogo/domain/review/presentation/ReviewController.kt
+++ b/src/main/kotlin/org/meogo/domain/review/presentation/ReviewController.kt
@@ -1,5 +1,7 @@
 package org.meogo.domain.review.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.meogo.domain.review.presentation.dto.request.ModifyReviewRequest
 import org.meogo.domain.review.presentation.dto.request.ReviewRequest
 import org.meogo.domain.review.service.CreateReviewService
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import javax.validation.Valid
 
+@Tag(name = "Review API")
 @RestController
 @RequestMapping("/review")
 class ReviewController(
@@ -36,6 +39,7 @@ class ReviewController(
     private val queryKeywordsService: QueryKeywordsService,
     private val queryMatchService: QueryMatchService
 ) {
+    @Operation(summary = "리뷰 작성")
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
     fun create(
@@ -46,10 +50,12 @@ class ReviewController(
     ) =
         createReviewService.execute(request, images)
 
+    @Operation(summary = "학교별 리뷰 조회")
     @GetMapping("/query")
     fun queryAllBySchoolId(@RequestParam(name = "school_id") schoolId: Int) =
         queryAllBySchoolIdService.queryAllBySchoolId(schoolId)
 
+    @Operation(summary = "리뷰 수정")
     @PatchMapping("/modify")
     fun modify(
         @RequestParam(name = "review_id") reviewId: Long,
@@ -58,21 +64,26 @@ class ReviewController(
     ) =
         modifyReviewService.modifyReview(reviewId, request, images)
 
+    @Operation(summary = "리뷰 삭제")
     @DeleteMapping
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     fun delete(@RequestParam(name = "review_id") reviewId: Long) =
         deleteReviewService.deleteReview(reviewId)
 
+    @Operation(summary = "학교별 리뷰 사진 조회")
     @GetMapping("/pic")
     fun queryReviewPicture(@RequestParam(name = "school_id") schoolId: Int) =
         queryReviewPictureService.queryReviewPicture(schoolId)
 
+    @Operation(summary = "라뷰 결과 조회")
     @GetMapping("/query/result")
     fun querySchoolReviewResult(@RequestParam(name = "school_id") schoolId: Int) = querySchoolReviewResultService.execute(schoolId)
 
+    @Operation(summary = "리뷰 키워드 반환")
     @GetMapping("/keyword")
     fun queryKeyword() = queryKeywordsService.execute()
 
+    @Operation(summary = "해당 학교인지 여부 반환")
     @GetMapping("/match")
     fun schoolMatch(@RequestParam(name = "school_id") schoolId: Int) =
         queryMatchService.execute(schoolId)

--- a/src/main/kotlin/org/meogo/domain/school/domain/School.kt
+++ b/src/main/kotlin/org/meogo/domain/school/domain/School.kt
@@ -1,0 +1,9 @@
+package org.meogo.domain.school.domain
+
+data class School(
+    val id: Int,
+    val link: String,
+    val schoolGubun: String,
+    val adres: String,
+    val schoolName: String
+)

--- a/src/main/kotlin/org/meogo/domain/school/enum/Gubun.kt
+++ b/src/main/kotlin/org/meogo/domain/school/enum/Gubun.kt
@@ -1,0 +1,5 @@
+package org.meogo.domain.school.enum
+
+enum class Gubun(val value: String) {
+    ELEM("elem_list"), MIDD("midd_list"), HIGH("high_list"), UNIV("univ_list"), SEET("seet_list"), ETC("alte_list")
+}

--- a/src/main/kotlin/org/meogo/domain/school/presentation/SchoolController.kt
+++ b/src/main/kotlin/org/meogo/domain/school/presentation/SchoolController.kt
@@ -1,0 +1,31 @@
+package org.meogo.domain.school.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.meogo.domain.school.enum.Gubun
+import org.meogo.domain.school.service.QuerySchoolService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "School API")
+@RestController
+@RequestMapping("/school")
+class SchoolController(
+    private val querySchoolService: QuerySchoolService
+) {
+
+    @Operation(summary = "학교 정보 조회")
+    @GetMapping
+    fun getSchools(
+        @RequestParam(name = "gubun")
+        gubun: Gubun,
+        @RequestParam(name = "regoion")
+        region: String?,
+        @RequestParam(name = "name")
+        name: String?,
+        @RequestParam(name = "sch1")
+        sch1: String?
+    ) = querySchoolService.execute(gubun, region, name, sch1)
+}

--- a/src/main/kotlin/org/meogo/domain/school/presentation/SchoolController.kt
+++ b/src/main/kotlin/org/meogo/domain/school/presentation/SchoolController.kt
@@ -21,7 +21,7 @@ class SchoolController(
     fun getSchools(
         @RequestParam(name = "gubun")
         gubun: Gubun,
-        @RequestParam(name = "regoion")
+        @RequestParam(name = "region")
         region: String?,
         @RequestParam(name = "name")
         name: String?,

--- a/src/main/kotlin/org/meogo/domain/school/service/QuerySchoolService.kt
+++ b/src/main/kotlin/org/meogo/domain/school/service/QuerySchoolService.kt
@@ -1,0 +1,14 @@
+package org.meogo.domain.school.service
+
+import org.meogo.domain.school.enum.Gubun
+import org.meogo.global.feign.CareerFeignClientService
+import org.springframework.stereotype.Service
+
+@Service
+class QuerySchoolService(
+    private val careerFeignClientService: CareerFeignClientService
+) {
+
+    fun execute(gubun: Gubun, region: String?, name: String?, sch1: String?) =
+        careerFeignClientService.getSchoolInfo(gubun, name, region, sch1).sortedBy { it.schoolName }
+}

--- a/src/main/kotlin/org/meogo/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/org/meogo/domain/user/presentation/UserController.kt
@@ -1,5 +1,7 @@
 package org.meogo.domain.user.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.meogo.domain.user.presentation.dto.request.UserCheckRequest
 import org.meogo.domain.user.presentation.dto.request.UserModifyRequest
 import org.meogo.domain.user.presentation.dto.request.UserSignInRequest
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import javax.validation.Valid
 
+@Tag(name = "User API")
 @RestController
 @RequestMapping("/user")
 class UserController(
@@ -32,6 +35,7 @@ class UserController(
     private val queryMyPageService: QueryMyPageService,
     private val modifyUserInfoService: ModifyUserInfoService
 ) {
+    @Operation(summary = "회원가입")
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     fun signUp(
@@ -40,18 +44,22 @@ class UserController(
     ): TokenResponse =
         userSignUpService.execute(request)
 
+    @Operation(summary = "로그인")
     @PostMapping("/signin")
     fun signIn(@RequestBody request: UserSignInRequest): TokenResponse =
         userSignInService.execute(request)
 
+    @Operation(summary = "아이디 중복 여부 반환")
     @PostMapping("/check")
     fun checkAccountId(@RequestBody request: UserCheckRequest): Boolean =
         userCheckAccountIdService.execute(request)
 
+    @Operation(summary = "마이페이지")
     @GetMapping("/my")
     fun myPage(): MyPageResponse =
         queryMyPageService.execute()
 
+    @Operation(summary = "마이페이지 수정")
     @PatchMapping("/modify")
     fun updateProfile(
         @RequestPart(name = "image")

--- a/src/main/kotlin/org/meogo/global/config/FcmConfig.kt
+++ b/src/main/kotlin/org/meogo/global/config/FcmConfig.kt
@@ -1,0 +1,42 @@
+package org.meogo.global.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import java.io.File
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import javax.annotation.PostConstruct
+
+@Configuration
+class FcmConfig(
+    @Value("\${firebase.url}")
+    private val url: String
+) {
+    @PostConstruct
+    fun initializeFirebaseApp() {
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                URL(url).openStream().use { inputStream ->
+                    Files.copy(inputStream, Paths.get(PATH))
+                    val tempfile = File(PATH)
+                    val options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(tempfile.inputStream()))
+                        .build()
+                    FirebaseApp.initializeApp(options)
+
+                    tempfile.delete()
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    companion object {
+        private const val PATH = "./firebase_credentials.json"
+    }
+}

--- a/src/main/kotlin/org/meogo/global/config/FcmConfig.kt
+++ b/src/main/kotlin/org/meogo/global/config/FcmConfig.kt
@@ -5,10 +5,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
-import java.io.File
 import java.net.URL
-import java.nio.file.Files
-import java.nio.file.Paths
 import javax.annotation.PostConstruct
 
 @Configuration
@@ -20,15 +17,13 @@ class FcmConfig(
     fun initializeFirebaseApp() {
         try {
             if (FirebaseApp.getApps().isEmpty()) {
+                // URL에서 InputStream을 열고 FirebaseOptions를 초기화
                 URL(url).openStream().use { inputStream ->
-                    Files.copy(inputStream, Paths.get(PATH))
-                    val tempfile = File(PATH)
                     val options = FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(tempfile.inputStream()))
+                        // InputStream을 통해 인증 정보 설정
+                        .setCredentials(GoogleCredentials.fromStream(inputStream))
                         .build()
                     FirebaseApp.initializeApp(options)
-
-                    tempfile.delete()
                 }
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/org/meogo/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/meogo/global/error/exception/ErrorCode.kt
@@ -25,5 +25,6 @@ enum class ErrorCode(
     ALREADY_GOOD_EXCEPTION(409, "You have already booked"),
 
     // Internal Server Error
-    INTERNAL_SERVER_ERROR(500, "Internal Server Error")
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+    FCM_SERVER_ERROR(500, "FCM Server Error")
 }

--- a/src/main/kotlin/org/meogo/global/feign/CareerFeignClient.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerFeignClient.kt
@@ -1,0 +1,19 @@
+package org.meogo.global.feign
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "career", url = "\${url.career}")
+interface CareerFeignClient {
+
+    @GetMapping("/getOpenApi")
+    fun getCareerInfoToEntity(
+        @RequestParam(name = FeignProperty.API_KEY) apiKey: String,
+        @RequestParam(name = FeignProperty.SVC_TYPE) svcType: String,
+        @RequestParam(name = FeignProperty.SVC_CODE) svcCode: String,
+        @RequestParam(name = FeignProperty.GUBUN) gubun: String,
+        @RequestParam(name = FeignProperty.CONTENT_TYPE) contentType: String,
+        @RequestParam(name = "perPage") perPage: Int,
+    ): String
+}

--- a/src/main/kotlin/org/meogo/global/feign/CareerFeignClient.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerFeignClient.kt
@@ -14,6 +14,9 @@ interface CareerFeignClient {
         @RequestParam(name = FeignProperty.SVC_CODE) svcCode: String,
         @RequestParam(name = FeignProperty.GUBUN) gubun: String,
         @RequestParam(name = FeignProperty.CONTENT_TYPE) contentType: String,
-        @RequestParam(name = "perPage") perPage: Int,
+        @RequestParam(name = FeignProperty.SEARCH_SCHOOL_NM) searchSchoolNm: String?,
+        @RequestParam(name = FeignProperty.REGION) region: String?,
+        @RequestParam(name = FeignProperty.SCH1) sch1: String?,
+        @RequestParam(name = "perPage") perPage: Int
     ): String
 }

--- a/src/main/kotlin/org/meogo/global/feign/CareerFeignClient.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerFeignClient.kt
@@ -17,6 +17,6 @@ interface CareerFeignClient {
         @RequestParam(name = FeignProperty.SEARCH_SCHOOL_NM) searchSchoolNm: String?,
         @RequestParam(name = FeignProperty.REGION) region: String?,
         @RequestParam(name = FeignProperty.SCH1) sch1: String?,
-        @RequestParam(name = "perPage") perPage: Int
+        @RequestParam(name = FeignProperty.PER_PAGE) perPage: Int
     ): String
 }

--- a/src/main/kotlin/org/meogo/global/feign/CareerFeignClientService.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerFeignClientService.kt
@@ -1,0 +1,49 @@
+package org.meogo.global.feign
+
+import com.google.gson.Gson
+import org.meogo.domain.school.domain.School
+import org.meogo.domain.school.enum.Gubun
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class CareerFeignClientService(
+    @Value("\${open-feign.career-key}")
+    private val careerKey: String,
+    private val careerFeignClient: CareerFeignClient
+) {
+    fun getSchoolInfo(gubun: Gubun, schoolName: String?, region: String?, sch1: String?): List<School> {
+        val schoolInfoSchool = careerFeignClient.getCareerInfoToEntity(
+            apiKey = careerKey,
+            svcType = FeignRequestProperty.SVC_TYPE,
+            svcCode = FeignRequestProperty.SVC_CODE,
+            gubun = gubun.value,
+            contentType = FeignRequestProperty.CONTENT_TYPE,
+            searchSchoolNm = schoolName,
+            region = region,
+            sch1 = sch1,
+            perPage = 100
+        )
+
+        val schoolInfoJson = Gson().fromJson(schoolInfoSchool, CareerSchoolListResponse::class.java)
+        val schoolList = addToList(schoolInfoJson)
+        return schoolList
+    }
+
+    fun addToList(schoolInfoJson: CareerSchoolListResponse): List<School> {
+        val schoolList = mutableListOf<School>()
+        for (school in schoolInfoJson.dataSearch.content) {
+            schoolList.add(
+                School(
+                    id = school.seq.toInt(),
+                    link = school.link,
+                    schoolGubun = school.let { it.schoolGubun }.toString(),
+                    adres = school.adres,
+                    schoolName = school.schoolName
+                )
+
+            )
+        }
+        return schoolList
+    }
+}

--- a/src/main/kotlin/org/meogo/global/feign/CareerFeignClientService.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerFeignClientService.kt
@@ -31,19 +31,15 @@ class CareerFeignClientService(
     }
 
     fun addToList(schoolInfoJson: CareerSchoolListResponse): List<School> {
-        val schoolList = mutableListOf<School>()
-        for (school in schoolInfoJson.dataSearch.content) {
-            schoolList.add(
-                School(
-                    id = school.seq.toInt(),
-                    link = school.link,
-                    schoolGubun = school.let { it.schoolGubun }.toString(),
-                    adres = school.adres,
-                    schoolName = school.schoolName
-                )
-
+        val content = schoolInfoJson.dataSearch.content ?: return emptyList()
+        return content.map { school ->
+            School(
+                id = school.seq.toInt(),
+                link = school.link,
+                schoolGubun = school.let { it.schoolGubun }.toString(),
+                adres = school.adres,
+                schoolName = school.schoolName
             )
         }
-        return schoolList
     }
 }

--- a/src/main/kotlin/org/meogo/global/feign/CareerFeignClientService.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerFeignClientService.kt
@@ -22,7 +22,7 @@ class CareerFeignClientService(
             searchSchoolNm = schoolName,
             region = region,
             sch1 = sch1,
-            perPage = 100
+            perPage = FeignRequestProperty.PER_PAGE
         )
 
         val schoolInfoJson = Gson().fromJson(schoolInfoSchool, CareerSchoolListResponse::class.java)

--- a/src/main/kotlin/org/meogo/global/feign/CareerSchoolResponse.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerSchoolResponse.kt
@@ -1,0 +1,19 @@
+package org.meogo.global.feign
+
+
+data class CareerSchoolListResponse(
+    val dataSearch: DataSearch
+)
+
+data class DataSearch(
+    val content: List<CareerSchoolResponse>
+)
+
+data class CareerSchoolResponse(
+    val seq: String,
+    val link: String,
+    val schoolGubun: String,
+    val adres: String,
+    val schoolName: String,
+    val estType: String
+)

--- a/src/main/kotlin/org/meogo/global/feign/CareerSchoolResponse.kt
+++ b/src/main/kotlin/org/meogo/global/feign/CareerSchoolResponse.kt
@@ -1,6 +1,5 @@
 package org.meogo.global.feign
 
-
 data class CareerSchoolListResponse(
     val dataSearch: DataSearch
 )
@@ -12,7 +11,7 @@ data class DataSearch(
 data class CareerSchoolResponse(
     val seq: String,
     val link: String,
-    val schoolGubun: String,
+    val schoolGubun: String?,
     val adres: String,
     val schoolName: String,
     val estType: String

--- a/src/main/kotlin/org/meogo/global/feign/FeignProperty.kt
+++ b/src/main/kotlin/org/meogo/global/feign/FeignProperty.kt
@@ -9,10 +9,12 @@ object FeignProperty {
     const val SEARCH_SCHOOL_NM = "searchSchulNm"
     const val REGION = "region"
     const val SCH1 = "sch1"
+    const val PER_PAGE = "perPage"
 }
 
 object FeignRequestProperty {
     const val SVC_TYPE = "api"
     const val SVC_CODE = "SCHOOL"
     const val CONTENT_TYPE = "json"
+    const val PER_PAGE = 500
 }

--- a/src/main/kotlin/org/meogo/global/feign/FeignProperty.kt
+++ b/src/main/kotlin/org/meogo/global/feign/FeignProperty.kt
@@ -1,0 +1,16 @@
+package org.meogo.global.feign
+
+object FeignProperty {
+    const val API_KEY = "apiKey"
+    const val SVC_TYPE = "svcType"
+    const val SVC_CODE = "svcCode"
+    const val GUBUN = "gubun"
+    const val CONTENT_TYPE = "contentType"
+}
+
+object FeignRequestProperty {
+    const val SVC_TYPE = "api"
+    const val SVC_CODE = "SCHOOL"
+    const val GUBUN = "high_list"
+    const val CONTENT_TYPE = "json"
+}

--- a/src/main/kotlin/org/meogo/global/feign/FeignProperty.kt
+++ b/src/main/kotlin/org/meogo/global/feign/FeignProperty.kt
@@ -6,11 +6,13 @@ object FeignProperty {
     const val SVC_CODE = "svcCode"
     const val GUBUN = "gubun"
     const val CONTENT_TYPE = "contentType"
+    const val SEARCH_SCHOOL_NM = "searchSchulNm"
+    const val REGION = "region"
+    const val SCH1 = "sch1"
 }
 
 object FeignRequestProperty {
     const val SVC_TYPE = "api"
     const val SVC_CODE = "SCHOOL"
-    const val GUBUN = "high_list"
     const val CONTENT_TYPE = "json"
 }

--- a/src/main/kotlin/org/meogo/global/utill/FcmUtil.kt
+++ b/src/main/kotlin/org/meogo/global/utill/FcmUtil.kt
@@ -1,0 +1,55 @@
+package org.meogo.global.utill
+
+import com.google.firebase.messaging.AndroidConfig
+import com.google.firebase.messaging.ApnsConfig
+import com.google.firebase.messaging.Aps
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import org.meogo.global.utill.exception.FcmException
+import org.springframework.stereotype.Component
+
+@Component
+class FcmUtil {
+    private val firebase: FirebaseMessaging
+        get() = FirebaseMessaging.getInstance()
+
+    fun sendMessage(fcmToken: List<String>, title: String, message: String) {
+        val message = messageSetting(fcmToken, title, message)
+
+        println("호우")
+        try {
+            firebase.sendMulticastAsync(message)
+        } catch (e: FirebaseMessagingException) {
+            throw FcmException
+        }
+
+        println("이게되네")
+    }
+
+    fun messageSetting(fcmToken: List<String>, title: String, message: String) =
+        MulticastMessage.builder()
+            .addAllTokens(fcmToken)
+            .setNotification(
+                Notification.builder()
+                    .setTitle(title)
+                    .setBody(message)
+                    .build()
+            )
+            .setAndroidConfig(
+                AndroidConfig.builder()
+                    .putData("title", title)
+                    .putData("body", message)
+                    .build()
+            )
+            .setApnsConfig(
+                ApnsConfig.builder()
+                    .setAps(
+                        Aps.builder()
+                            .putCustomData("title", title)
+                            .putCustomData("body", message)
+                            .build()
+                    ).build()
+            ).build()
+}

--- a/src/main/kotlin/org/meogo/global/utill/exception/FcmException.kt
+++ b/src/main/kotlin/org/meogo/global/utill/exception/FcmException.kt
@@ -1,0 +1,8 @@
+package org.meogo.global.utill.exception
+
+import org.meogo.global.error.exception.ErrorCode
+import org.meogo.global.error.exception.MeogoException
+
+object FcmException : MeogoException(
+    ErrorCode.FCM_SERVER_ERROR
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  spring:
+    config.activate.on-profile: default
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}
@@ -9,7 +11,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: false
+    show-sql: true
     properties:
       hibernate:
         format_sql: true
@@ -42,6 +44,12 @@ cloud:
 
 firebase:
   url: ${FCM_URL}
+
+url:
+  career: ${CAREER_URL}
+
+open-feign:
+  career-key: ${CAREER_KEY}
 
 server:
   port: 8989


### PR DESCRIPTION
close #52 
<img width="612" alt="커리어넷" src="https://github.com/user-attachments/assets/2134b7be-cca0-4c75-8f5b-6da8de58d18a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
	- Spring Cloud OpenFeign을 사용하여 선언적 REST 클라이언트 기능 추가.
	- `School`, `Gubun`, `CareerSchoolListResponse`, `DataSearch`, `CareerSchoolResponse` 데이터 클래스 및 `CareerFeignClient`, `CareerFeignClientService`, `QuerySchoolService`, `FcmUtil`, `FcmConfig` 서비스 추가.
	- `SchoolController`, `UserController`, `BookmarkController`, `CommentController`, `PostController`, `QuestionController`, `ReviewController`에 API 문서화 개선을 위한 OpenAPI 주석 추가.
- **버그 수정**
	- FCM 관련 서버 오류 처리 추가.
- **구성 변경**
	- `application.yml` 파일에 SQL 로깅 활성화 및 새로운 URL 및 OpenFeign 속성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->